### PR TITLE
removed beginning/ending whitespace from overlay template

### DIFF
--- a/lib/material-steppers.ts
+++ b/lib/material-steppers.ts
@@ -274,12 +274,10 @@ angular.module('mdSteppers', ['ngMaterial'])
                 function addOverlay() {
                     let hasOverlay = !!iElement.find('.md-step-body-overlay')[0];
                     if (!hasOverlay) {
-                        let overlay = angular.element(`
-                            <div class="md-step-body-overlay"></div>
+                        let overlay = angular.element(`<div class="md-step-body-overlay"></div>
                             <div class="md-step-body-loading">
                                 <md-progress-circular md-mode="indeterminate"></md-progress-circular>
-                            </div>
-                        `);
+                            </div>`);
                         $compile(overlay)(scope);
                         iElement.find('.md-steppers-scope').append(overlay);
                     }


### PR DESCRIPTION
with certain versions of jQuery (1.9.1 for example), angular.element has an issue with templates that have whitespace in the beginning or end of the string, throwing:

Error: Syntax error, unrecognized expression: ...

the original whitespace was included as a small benefit to code readability, and not for functional reasons, so removing this should have no side effects.

other means of correcting this behavior would be to use js's .trim method, $.trim or create an angular trim filter. however, in this case, the removal of whitespace within the template itself seemed the most reasonable approach.

thank you so much for creating material-steppers and allowing others to benefit from your work. i have enjoyed using it!
bill
